### PR TITLE
Add Kafka consumer in Notification Service

### DIFF
--- a/src/main/java/org/example/notificationservice/service/NotificationService.java
+++ b/src/main/java/org/example/notificationservice/service/NotificationService.java
@@ -1,0 +1,17 @@
+package org.example.notificationservice.service;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@Service
+public class NotificationService {
+  Logger logger = Logger.getLogger(getClass().getName());
+
+  @KafkaListener(topics = "notificationTopic", groupId = "notification-service-group")
+  public void listen(String orderId) {
+    logger.log(Level.INFO, "Order received with order id : {0}", orderId);
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,9 @@
 spring.application.name=notification-service
+
+server.port=8081
+
+# Kafka Properties
+spring.kafka.consumer.bootstrap-servers=localhost:9092
+spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
+spring.kafka.consumer.value-deserializer=org.apache.kafka.common.serialization.StringDeserializer
+spring.kafka.consumer.group-id=notification-service-group


### PR DESCRIPTION
### Description:
This pull request introduces the implementation of a Kafka consumer in the Notification Service application.

### Changes:
- **Add NotificationService:** Added `NotificationService` class with a method annotated with `@KafkaListener` to consume messages from the `notificationTopic` Kafka topic.
- **Add Kafka Consumer Properties:** Added Kafka consumer properties in `application.properties`.

### Purpose:
The purpose of this pull request is to enable the Notification Service to consume order notification messages published to the `notificationTopic` Kafka topic by the Order Service. When a message is received, the Notification Service will log the order ID for further processing, such as sending notifications to customers or performing other related tasks.